### PR TITLE
Raise error in time series builder when supplying value of unsupported type

### DIFF
--- a/python/xviz_avs/builder/time_series.py
+++ b/python/xviz_avs/builder/time_series.py
@@ -75,7 +75,7 @@ class XVIZTimeSeriesBuilder(XVIZBaseBuilder):
         elif isinstance(self._value, float):
             field_name = "doubles"
         else:
-            self._logger.error("The type of input value is not recognized!")
+            raise TypeError(f"The type of input value, {type(self._value)}, is not recognized! It must be str, bool, int, or float.")
 
         ts_entry = self._data.get(self._timestamp)
         if ts_entry:


### PR DESCRIPTION
Currently, the time series builder will error with "unbound variable error, local variable "field_name" referenced before assigned" if the time series builder is supplied with a value of unsupported type.  This PR changes logging an error message to raising a TypeError when this happens. 